### PR TITLE
new simple_spend method

### DIFF
--- a/source/includes/_microtx.md
+++ b/source/includes/_microtx.md
@@ -72,8 +72,8 @@ $.post(url, JSON.stringify(microtx))
 
 ```python
 # The python library includes a method that will sign and verify a transaction client-side, so your private key never leaves your computer. It should be used instead for security:
->>> from blockcypher import simple_spend_tx
->>> simple_spend_tx(from_privkey_hex='97838249d77bfa65f97be02b63fd1b7bb6a58474c7c22784a0da63993d1c2f90', to_address='C1rGdt7QEPGiwPMFhNKNhHmyoWpa5X92pn', to_satoshis=10000, coin_symbol='bcy')
+>>> from blockcypher import simple_spend
+>>> simple_spend(from_privkey='97838249d77bfa65f97be02b63fd1b7bb6a58474c7c22784a0da63993d1c2f90', to_address='C1rGdt7QEPGiwPMFhNKNhHmyoWpa5X92pn', to_satoshis=10000, coin_symbol='bcy')
 '7981c7849294648c1e79dd16077a388b808fcf8c20035aec7cc5315b37dacfee'
 
 # If you prefer to use the MicroTX endpoint (say for the wait_guarantee), here's how to do that:

--- a/source/includes/_tx.md
+++ b/source/includes/_tx.md
@@ -736,10 +736,10 @@ $.post('https://api.blockcypher.com/v1/bcy/test/txs/new', JSON.stringify(newtx))
 
 ```python
 # Creating transactions manually is very complicated.
-# We recommend you look at blockcypher.simple_spend_tx() for a full working example of building a transaction using the blockcypher API, verifying and signing that transactionally locally, and then broadcasting it to the network using blockypher's API
-# With blockcypher.simple_spend_tx(), this whole example would look like just the following:
->>> from blockcypher import simple_spend_tx
->>> simple_spend_tx(from_privkey_hex='97838249d77bfa65f97be02b63fd1b7bb6a58474c7c22784a0da63993d1c2f90', to_address='C1rGdt7QEPGiwPMFhNKNhHmyoWpa5X92pn', to_satoshis=1000000, coin_symbol='bcy')
+# We recommend you look at blockcypher.simple_spend() for a full working example of building a transaction using the blockcypher API, verifying and signing that transactionally locally, and then broadcasting it to the network using blockypher's API
+# With blockcypher.simple_spend(), this whole example would look like just the following:
+>>> from blockcypher import simple_spend
+>>> simple_spend_tx(from_privkey='97838249d77bfa65f97be02b63fd1b7bb6a58474c7c22784a0da63993d1c2f90', to_address='C1rGdt7QEPGiwPMFhNKNhHmyoWpa5X92pn', to_satoshis=1000000, coin_symbol='bcy')
 '7981c7849294648c1e79dd16077a388b808fcf8c20035aec7cc5315b37dacfee'
 
 # That said, here it is in parts


### PR DESCRIPTION
`simple_spend_tx` has been replaced with `simple_spend` (discussion here IYC: https://github.com/blockcypher/blockcypher-python/issues/20), so I wanted to update the docs to reflect that.

Thanks!